### PR TITLE
[fix] compiler error: {#- RULES ... -#} ghc 7.6.3

### DIFF
--- a/src/Data/MemoTrie.hs
+++ b/src/Data/MemoTrie.hs
@@ -98,9 +98,7 @@ untrie3 tt = untrie2 . untrie tt
 -}
 
 
-{-# RULES
-"trie/untrie"   forall t. trie (untrie t) = t
- #-}
+{-# RULES "trie/untrie"   forall t. trie (untrie t) = t #-}
 
 -- Don't include the dual rule:
 --   "untrie/trie"   forall f. untrie (trie f) = f


### PR DESCRIPTION
this fixes compilation issues at least on os x 10.9.1 ghc 7.6.3

```
src/Data/MemoTrie.hs:103:3:
   error: invalid preprocessing directive
   #-}
    ^
```
