### PR TITLE
[fix] compilation errors on base <4.8 (i.e. GHC <7.10)

### DIFF
--- a/MemoTrie.cabal
+++ b/MemoTrie.cabal
@@ -37,6 +37,7 @@ Library
                   , newtype-generics >= 0.4
   else
      Build-Depends: base <4.8.0.0, void
+                  , newtype-generics >= 0.4
 
   Exposed-Modules:     
                      Data.MemoTrie

--- a/src/Data/MemoTrie.hs
+++ b/src/Data/MemoTrie.hs
@@ -64,9 +64,13 @@ module Data.MemoTrie
 import Data.Bits
 import Data.Word
 import Data.Int
--- import Control.Applicative
+#if !MIN_VERSION_base(4,8,0)
+import Control.Applicative
+#endif
 import Control.Arrow (first,(&&&))
--- import Data.Monoid
+#if !MIN_VERSION_base(4,8,0)
+import Data.Monoid
+#endif
 import Data.Function (on)
 import GHC.Generics
 


### PR DESCRIPTION
This fixes compilation errors on base <4.8 (i.e. GHC <7.10).
