### PR TITLE
Data.Memotrie:  Semigroup instance for :->: (GHC 8.4 compat)

### DIFF
--- a/src/Data/MemoTrie.hs
+++ b/src/Data/MemoTrie.hs
@@ -587,7 +587,12 @@ instance HasTrie a => Monad ((:->:) a) where
 
 instance (HasTrie a, Monoid b) => Monoid (a :->: b) where
   mempty  = trie mempty
+#if !MIN_VERSION_base(4,11,0)
   mappend = inTrie2 mappend
+#else
+instance (HasTrie a, Semigroup b) => Semigroup (a :->: b) where
+  (<>)    = inTrie2 (<>)
+#endif
 
 instance HasTrie a => Functor ((:->:) a) where
   fmap f = inTrie (fmap f)


### PR DESCRIPTION
Tested on GHC 8.4.1-alpha1 and 8.0.2.

The failure on 8.4.1, otherwise is:

```
Building library for MemoTrie-0.6.8..
[1 of 1] Compiling Data.MemoTrie    ( src/Data/MemoTrie.hs, dist/build/Data/MemoTrie.o )

src/Data/MemoTrie.hs:588:10: error:
    • Could not deduce (Semigroup (a :->: b))
        arising from the superclasses of an instance declaration
      from the context: (HasTrie a, Monoid b)
        bound by the instance declaration at src/Data/MemoTrie.hs:588:10-51
    • In the instance declaration for ‘Monoid (a :->: b)’
    |
588 | instance (HasTrie a, Monoid b) => Monoid (a :->: b) where
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
builder for ‘/nix/store/anxgazq5skf8n9g9gji30zf53r5008p3-MemoTrie-0.6.8.drv’ failed with exit code 1
```