### PR TITLE
Remove newtype-generics dependency

### DIFF
--- a/MemoTrie.cabal
+++ b/MemoTrie.cabal
@@ -1,5 +1,5 @@
 Name:                MemoTrie
-Version:             0.6.11
+Version:             0.7.0
 Cabal-Version:       >= 1.10
 Synopsis:            Trie-based memo functions
 Category:            Data
@@ -33,9 +33,9 @@ Library
   hs-Source-Dirs:      src
 
   if impl(ghc >= 7.10.0)
-     Build-Depends: base >=4.8.0.0 && <5, newtype-generics >= 0.5.3
+     Build-Depends: base >=4.8.0.0 && <5
   else
-     Build-Depends: base <4.8.0.0, void, newtype-generics >= 0.5.3
+     Build-Depends: base <4.8.0.0, void
 
   Exposed-Modules:     
                      Data.MemoTrie


### PR DESCRIPTION
@conal I saw this dependency was added in 2016, but I'm not sure what the point of it is. Can it be removed?

Context: newtype-generics is not really maintained anymore: https://github.com/sjakobi/newtype-generics/issues/18. Since MemoTrie is used by ormolu and fourmolu, then making ormolu/fourmolu build with GHC 9.8 is blocked by newtype-generics because of MemoTrie.