### PR TITLE
Fix the encoded Copyright sign in the package description

### DIFF
--- a/MemoTrie.cabal
+++ b/MemoTrie.cabal
@@ -10,7 +10,7 @@ Description:
   .
   Project wiki page: <http://haskell.org/haskellwiki/MemoTrie>
   .
-  &#199; 2008-2019 by Conal Elliott; BSD3 license.
+  &#169; 2008-2019 by Conal Elliott; BSD3 license.
 Homepage:            https://github.com/conal/MemoTrie
 Author:              Conal Elliott 
 Maintainer:          conal@conal.net


### PR DESCRIPTION
Fix the html `&copy;` (`&#169;` Copyright) sign in the package description.

Presumably C cedilla was not intended

For reference: https://www.w3.org/MarkUp/html-spec/html-spec_13.html

(Though there is already Copyright field in the .cabal file :-)