### PR TITLE
Remove noncanonical definitions

### DIFF
--- a/src/Data/MemoTrie.hs
+++ b/src/Data/MemoTrie.hs
@@ -601,7 +601,9 @@ instance HasTrie a => Applicative ((:->:) a) where
   (<*>)  = inTrie2 (<*>)
 
 instance HasTrie a => Monad ((:->:) a) where
+#if !MIN_VERSION_base(4,8,0)
   return a = trie (return a)
+#endif
   u >>= k  = trie (untrie u >>= untrie . k)
 
 -- | Identity trie


### PR DESCRIPTION
This appeases the -Wnoncanonical-monad-instances warning. This warning exists because a future GHC release may treat noncanonical definitions as errors.

See also:
  https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/monad-of-no-return