### PR TITLE
Remove noncanonical definitions.

### DIFF
--- a/src/Data/MemoTrie.hs
+++ b/src/Data/MemoTrie.hs
@@ -603,7 +603,6 @@ instance HasTrie a => Applicative ((:->:) a) where
   (<*>)  = inTrie2 (<*>)
 
 instance HasTrie a => Monad ((:->:) a) where
-  return a = trie (return a)
   u >>= k  = trie (untrie u >>= untrie . k)
 
 -- | Identity trie


### PR DESCRIPTION
This appeases the `-Wnoncanonical-monad-instances` warning. A future GHC release will treat noncanonical definitions as errors. See https://github.com/haskell/core-libraries-committee/issues/328.